### PR TITLE
Allows sidebar to be closed when project ID exists

### DIFF
--- a/src/features/projects/view/client/ProjectsPage.tsx
+++ b/src/features/projects/view/client/ProjectsPage.tsx
@@ -71,11 +71,7 @@ export default function ProjectsPage({
   }
   return (
     <SidebarContainer
-      canCloseDrawer={
-        project !== undefined &&
-        version !== undefined &&
-        specification !== undefined
-      }
+      canCloseDrawer={projectId !== undefined}
       forceClose={forceCloseSidebar}
       sidebar={
         <ProjectList


### PR DESCRIPTION
Fixes an issue where the sidebar could not be closed on mobile when the "The project was not found" error message was shown because `project` was undefined.

This is an issue when the user opens a project that does not exist by navigating directly to the URL, e.g. by visiting docs.shapetools.io/foo, because the sidebar would remain open on mobile preventing the user from seeing the error message.