### PR TITLE
Fixes webhooks attempting to authenticate

### DIFF
--- a/src/composition.ts
+++ b/src/composition.ts
@@ -63,19 +63,21 @@ const accessTokenService = new LockingAccessTokenService(
   )
 )
 
-export const gitHubClient = new AccessTokenRefreshingGitHubClient(
+export const gitHubClient = new GitHubClient({
+  appId: GITHUB_APP_ID,
+  clientId: GITHUB_CLIENT_ID,
+  clientSecret: GITHUB_CLIENT_SECRET,
+  privateKey: gitHubPrivateKey,
+  accessTokenReader: accessTokenService
+})
+
+const userGitHubClient = new AccessTokenRefreshingGitHubClient(
   accessTokenService,
-  new GitHubClient({
-    appId: GITHUB_APP_ID,
-    clientId: GITHUB_CLIENT_ID,
-    clientSecret: GITHUB_CLIENT_SECRET,
-    privateKey: gitHubPrivateKey,
-    accessTokenReader: accessTokenService
-  })
+  gitHubClient
 )
 
 export const sessionValidator = new GitHubOrganizationSessionValidator(
-  gitHubClient,
+  userGitHubClient,
   GITHUB_ORGANIZATION_NAME
 )
 
@@ -93,7 +95,7 @@ export const projectDataSource = new CachingProjectDataSource(
   new SessionValidatingProjectDataSource(
     sessionValidator,
     new GitHubProjectDataSource(
-      gitHubClient,
+      userGitHubClient,
       GITHUB_ORGANIZATION_NAME
     )
   ),


### PR DESCRIPTION
This PR fixes an issue where our web hooks would attempt to access the user session, however, no user is logged in when executing a webhook.

The regression was introduced in #113 where we decorate our GitHubClient with a AccessTokenRefreshingGitHubClient which makes all invocations of GitHubClient authenticated. However, that causes errors when using the GitHub client through a webhook.

To fix the issue we ensure that our webhooks do not use an instance of AccessTokenRefreshingGitHubClient but rather uses an instance of GitHubClient directly.