### PR TITLE
/api/github/blob/{...} uses userGitHubClient

### DIFF
--- a/src/app/api/github/blob/[owner]/[repository]/[...path]/route.ts
+++ b/src/app/api/github/blob/[owner]/[repository]/[...path]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { gitHubClient } from "@/composition"
+import { userGitHubClient } from "@/composition"
 
 interface GetBlobParams {
   owner: string
@@ -9,7 +9,7 @@ interface GetBlobParams {
 
 export async function GET(req: NextRequest, { params }: { params: GetBlobParams }) {
   const path = params.path.join("/")
-  const item = await gitHubClient.getRepositoryContent({
+  const item = await userGitHubClient.getRepositoryContent({
     repositoryOwner: params.owner,
     repositoryName: params.repository,
     path: path,

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -82,7 +82,7 @@ export const gitHubClient = new GitHubClient({
   accessTokenReader: accessTokenService
 })
 
-const userGitHubClient = new AccessTokenRefreshingGitHubClient(
+export const userGitHubClient = new AccessTokenRefreshingGitHubClient(
   accessTokenService,
   gitHubClient
 )


### PR DESCRIPTION
This fixes a bug where loading a file from GitHub could fail with HTTP 401, i.e. invalid credentials, without retrying with a new access token.

We could consider if this endpoint should live under the /api/user/ namespace to indicate that it relies on user data.