### PR TITLE
Expires values cached in Redis

### DIFF
--- a/__test__/auth/CachingRepositoryAccessReaderConfig.ts
+++ b/__test__/auth/CachingRepositoryAccessReaderConfig.ts
@@ -9,6 +9,7 @@ test("It fetches repository names for user if they are not cached", async () => 
         return null
       },
       async set() {},
+      async setExpiring() {},
       async delete() {}
     },
     repositoryAccessReader: {
@@ -32,6 +33,7 @@ test("It does not fetch repository names if they are cached", async () => {
         return "[\"foo\"]"
       },
       async set() {},
+      async setExpiring() {},
       async delete() {}
     },
     repositoryAccessReader: {
@@ -57,6 +59,7 @@ test("It caches fetched repository names for user", async () => {
         cachedUserId = userId
         cachedRepositoryNames = value
       },
+      async setExpiring() {},
       async delete() {}
     },
     repositoryAccessReader: {
@@ -77,6 +80,7 @@ test("It decodes cached repository names", async () => {
         return "[\"foo\",\"bar\"]"
       },
       async set() {},
+      async setExpiring() {},
       async delete() {}
     },
     repositoryAccessReader: {

--- a/__test__/auth/CachingUserIdentityProviderReader.test.ts
+++ b/__test__/auth/CachingUserIdentityProviderReader.test.ts
@@ -8,6 +8,7 @@ test("It fetches user identity provider if it is not cached", async () => {
       return null
     },
     async set() {},
+    async setExpiring() {},
     async delete() {}
   }, {
     async getUserIdentityProvider() {
@@ -26,6 +27,7 @@ test("It does not fetch user identity provider if it is cached", async () => {
       return UserIdentityProvider.GITHUB
     },
     async set() {},
+    async setExpiring() {},
     async delete() {}
   }, {
     async getUserIdentityProvider() {
@@ -44,7 +46,8 @@ test("It caches fetched user identity provider for user", async () => {
     async get() {
       return null
     },
-    async set(userId, userIdentityProvider) {
+    async set() {},
+    async setExpiring(userId, userIdentityProvider) {
       cachedUserId = userId
       cachedUserIdentityProvider = userIdentityProvider
     },

--- a/__test__/auth/GuestAccessTokenService.test.ts
+++ b/__test__/auth/GuestAccessTokenService.test.ts
@@ -13,7 +13,7 @@ test("It gets the access token for the user", async () => {
         readUserId = userId
         return "foo"
       },
-      async set() {}
+      async setExpiring() {}
     },
     dataSource: {
       async getAccessToken() {
@@ -38,7 +38,7 @@ test("It refreshes access token on demand when there is no cached access token",
       async get() {
         return null
       },
-      async set() {}
+      async setExpiring() {}
     },
     dataSource: {
       async getAccessToken() {

--- a/__test__/auth/OAuthTokenRepository.test.ts
+++ b/__test__/auth/OAuthTokenRepository.test.ts
@@ -11,6 +11,7 @@ test("It reads the auth token for the specified user", async () => {
       })
     },
     async set() {},
+    async setExpiring() {},
     async delete() {}
   })
   await sut.get("1234")
@@ -24,7 +25,8 @@ test("It stores the auth token for the specified user", async () => {
     async get() {
       return ""
     },
-    async set(userId, data) {
+    async set() {},
+    async setExpiring(userId, data) {
       storedUserId = userId
       storedJSON = data
     },
@@ -48,6 +50,7 @@ test("It deletes the auth token for the specified user", async () => {
       return ""
     },
     async set() {},
+    async setExpiring() {},
     async delete(userId) {
       deletedUserId = userId
     }

--- a/__test__/common/userData/KeyValueUserDataRepository.test.ts
+++ b/__test__/common/userData/KeyValueUserDataRepository.test.ts
@@ -8,6 +8,7 @@ test("It reads the expected key", async () => {
       return ""
     },
     async set() {},
+    async setExpiring() {},
     async delete() {}
   }, "foo")
   await sut.get("123")
@@ -23,12 +24,31 @@ test("It stores values under the expected key", async () => {
     async set(key) {
       storedKey = key
     },
+    async setExpiring() {},
     async delete() {}
   }, "foo")
   await sut.set("123", "bar")
   expect(storedKey).toBe("foo[123]")
 })
 
+test("It stores values under the expected key with expected time to live", async () => {
+  let storedKey: string | undefined
+  let storedTimeToLive: number | undefined
+  const sut = new KeyValueUserDataRepository({
+    async get() {
+      return ""
+    },
+    async set() {},
+    async setExpiring(key, _value, timeToLive) {
+      storedKey = key
+      storedTimeToLive = timeToLive
+    },
+    async delete() {}
+  }, "foo")
+  await sut.setExpiring("123", "bar", 24 * 3600)
+  expect(storedKey).toBe("foo[123]")
+  expect(storedTimeToLive).toBe(24 * 3600)
+})
 
 test("It deletes the expected key", async () => {
   let deletedKey: string | undefined
@@ -37,6 +57,7 @@ test("It deletes the expected key", async () => {
       return ""
     },
     async set() {},
+    async setExpiring() {},
     async delete(key) {
       deletedKey = key
     }

--- a/src/common/keyValueStore/IKeyValueStore.ts
+++ b/src/common/keyValueStore/IKeyValueStore.ts
@@ -1,5 +1,10 @@
 export default interface IKeyValueStore {
   get(key: string): Promise<string | null>
   set(key: string, data: string | number | Buffer): Promise<void>
+  setExpiring(
+    key: string,
+    data: string | number | Buffer,
+    timeToLive: number
+  ): Promise<void>
   delete(key: string): Promise<void>
 }

--- a/src/common/keyValueStore/RedisKeyValueStore.ts
+++ b/src/common/keyValueStore/RedisKeyValueStore.ts
@@ -16,6 +16,14 @@ export default class RedisKeyValueStore implements IKeyValueStore {
     await this.redis.set(key, data)
   }
   
+  async setExpiring(
+    key: string,
+    data: string | number | Buffer,
+    timeToLive: number
+  ): Promise<void> {
+    await this.redis.setex(key, timeToLive, data)
+  }
+  
   async delete(key: string): Promise<void> {
     await this.redis.del(key)
   }

--- a/src/common/userData/IUserDataRepository.ts
+++ b/src/common/userData/IUserDataRepository.ts
@@ -1,5 +1,6 @@
 export default interface IUserDataRepository<T> {
   get(userId: string): Promise<T | null>
   set(userId: string, value: T): Promise<void>
+  setExpiring(userId: string, value: T, timeToLive: number): Promise<void>
   delete(userId: string): Promise<void>
 }

--- a/src/common/userData/KeyValueUserDataRepository.ts
+++ b/src/common/userData/KeyValueUserDataRepository.ts
@@ -18,6 +18,10 @@ export default class KeyValueUserDataRepository implements IUserDataRepository<s
     await this.store.set(this.getKey(userId), value)
   }
   
+  async setExpiring(userId: string, value: string, timeToLive: number): Promise<void> {
+    await this.store.setExpiring(this.getKey(userId), value, timeToLive)
+  }
+  
   async delete(userId: string): Promise<void> {
     await this.store.delete(this.getKey(userId))
   }

--- a/src/features/auth/domain/accessToken/GuestAccessTokenService.ts
+++ b/src/features/auth/domain/accessToken/GuestAccessTokenService.ts
@@ -6,7 +6,7 @@ export interface IUserIDReader {
 
 export interface Repository {
   get(userId: string): Promise<string | null>
-  set(userId: string, token: string): Promise<void>
+  setExpiring(userId: string, token: string, timeToLive: number): Promise<void>
 }
 
 export interface DataSource {
@@ -47,7 +47,7 @@ export default class GuestAccessTokenService implements IAccessTokenService {
   private async getNewAccessToken(): Promise<string> {
     const userId = await this.userIdReader.getUserId()
     const newAccessToken = await this.dataSource.getAccessToken(userId)
-    await this.repository.set(userId, newAccessToken)
+    await this.repository.setExpiring(userId, newAccessToken, 7 * 24 * 3600)
     return newAccessToken
   }
 }

--- a/src/features/auth/domain/oAuthToken/OAuthTokenRepository.ts
+++ b/src/features/auth/domain/oAuthToken/OAuthTokenRepository.ts
@@ -19,7 +19,7 @@ export default class OAuthTokenRepository implements IOAuthTokenRepository {
   
   async set(userId: string, token: OAuthToken): Promise<void> {
     const string = ZodJSONCoder.encode(OAuthTokenSchema, token)
-    await this.repository.set(userId, string)
+    await this.repository.setExpiring(userId, string, 6 * 30 * 24 * 3600)
   }
   
   async delete(userId: string): Promise<void> {

--- a/src/features/auth/domain/repositoryAccess/CachingRepositoryAccessReaderConfig.ts
+++ b/src/features/auth/domain/repositoryAccess/CachingRepositoryAccessReaderConfig.ts
@@ -48,7 +48,7 @@ export default class CachingRepositoryAccessReader {
     const repositoryNames = await this.repositoryAccessReader.getRepositoryNames(userId)
     try {
       const str = ZodJSONCoder.encode(RepositoryNamesContainerSchema, repositoryNames)
-      await this.repository.set(userId, str)
+      await this.repository.setExpiring(userId, str, 7 * 24 * 3600)
     } catch (error: unknown) {
       console.error(error)
     }

--- a/src/features/auth/domain/userIdentityProvider/CachingUserIdentityProviderReader.ts
+++ b/src/features/auth/domain/userIdentityProvider/CachingUserIdentityProviderReader.ts
@@ -19,7 +19,7 @@ export default class CachingUserIdentityProviderReader implements IUserIdentityP
       return cachedValue as UserIdentityProvider
     } else {
       const userIdentity = await this.reader.getUserIdentityProvider(userId)
-      await this.repository.set(userId, userIdentity.toString())
+      await this.repository.setExpiring(userId, userIdentity.toString(), 7 * 24 * 3600)
       return userIdentity
     }
   }

--- a/src/features/projects/domain/ProjectRepository.ts
+++ b/src/features/projects/domain/ProjectRepository.ts
@@ -29,7 +29,7 @@ export default class ProjectRepository implements IProjectRepository {
   async set(projects: Project[]): Promise<void> {
     const userId = await this.userIDReader.getUserId()
     const string = ZodJSONCoder.encode(ProjectSchema.array(), projects)
-    await this.repository.set(userId, string)
+    await this.repository.setExpiring(userId, string, 30 * 24 * 3600)
   }
   
   async delete(): Promise<void> {


### PR DESCRIPTION
With the changes in this PR we started expiring values cached in Redis. As a rule of thumb the expiration is set to the following:

- OAuth tokens for GitHub users expire after six months.
- User information for guests expire after a week.
- Cached projects expire after a month.