### PR TITLE
Makes parsing of project config safer

### DIFF
--- a/src/features/projects/domain/IProjectConfig.ts
+++ b/src/features/projects/domain/IProjectConfig.ts
@@ -1,17 +1,25 @@
-export type ProjectConfigRemoteVersion = {
-  readonly id?: string
-  readonly name: string
-  readonly specifications: ProjectConfigRemoteSpecification[]
-}
+import { z } from "zod"
 
-export type ProjectConfigRemoteSpecification = {
-  readonly id?: string
-  readonly name: string
-  readonly url: string
-}
+export const ProjectConfigRemoteSpecificationSchema = z.object({
+  id: z.coerce.string().optional(),
+  name: z.coerce.string(),
+  url: z.string()
+})
 
-export default interface IProjectConfig {
-  readonly name?: string
-  readonly image?: string
-  readonly remoteVersions?: ProjectConfigRemoteVersion[]
-}
+export const ProjectConfigRemoteVersionSchema = z.object({
+  id: z.coerce.string().optional(),
+  name: z.coerce.string(),
+  specifications: ProjectConfigRemoteSpecificationSchema.array()
+})
+
+export const IProjectConfigSchema = z.object({
+  name: z.coerce.string().optional(),
+  image: z.string().optional(),
+  remoteVersions: ProjectConfigRemoteVersionSchema.array().optional()
+})
+
+export type ProjectConfigRemoteSpecification = z.infer<typeof ProjectConfigRemoteSpecificationSchema>
+export type ProjectConfigRemoteVersion = z.infer<typeof ProjectConfigRemoteVersionSchema>
+export type IProjectConfig = z.infer<typeof IProjectConfigSchema>
+
+export default IProjectConfig

--- a/src/features/projects/domain/ProjectConfigParser.ts
+++ b/src/features/projects/domain/ProjectConfigParser.ts
@@ -1,13 +1,12 @@
-import { parse } from 'yaml'
-import IProjectConfig from "./IProjectConfig"
+import { parse } from "yaml"
+import IProjectConfig, { IProjectConfigSchema } from "./IProjectConfig"
 
 export default class ProjectConfigParser {
   parse(rawConfig: string): IProjectConfig {
     const obj = parse(rawConfig)
-    if (obj !== null) {
-      return obj
-    } else {
+    if (obj === null) {
       return {}
     }
+    return IProjectConfigSchema.parse(obj)
   }
 }


### PR DESCRIPTION
This PR uses zod to make it safer to parse project configurations. Specifically this solves two issues:

- Automatically converts numbers to string when possible using `z.coerce`.
- Throws clearer errors when parsing fails.