### PR TITLE
Enable persistAuthorization for Swagger UI

### DIFF
--- a/src/features/docs/view/Swagger.tsx
+++ b/src/features/docs/view/Swagger.tsx
@@ -7,7 +7,7 @@ const Swagger = ({ url }: { url: string }) => {
   const [isLoading, setLoading] = useState(true)
   return (
     <LoadingWrapper showLoadingIndicator={isLoading}>
-      <SwaggerUI url={url} onComplete={() => setLoading(false)} deepLinking />
+      <SwaggerUI url={url} onComplete={() => setLoading(false)} deepLinking persistAuthorization />
     </LoadingWrapper>
   )
 }


### PR DESCRIPTION
This PR enables `persistAuthorization` on Swagger UI which causes Swagger UI to remeber the credentals provided between reloads.

This behavior is similar to the default behavior of Stoplight.

For both viewers the credentials are stored in local storage.
