### PR TITLE
Enable persistAuthorization for Swagger UI

### DIFF
--- a/src/features/docs/view/Swagger.tsx
+++ b/src/features/docs/view/Swagger.tsx
@@ -7,7 +7,7 @@ const Swagger = ({ url }: { url: string }) => {
   const [isLoading, setLoading] = useState(true)
   return (
     <LoadingWrapper showLoadingIndicator={isLoading}>
-      <SwaggerUI url={url} onComplete={() => setLoading(false)} deepLinking />
+      <SwaggerUI url={url} onComplete={() => setLoading(false)} deepLinking persistAuthorization />
     </LoadingWrapper>
   )
 }


### PR DESCRIPTION
## Description

Enables `persistAuthorization` for Swagger UI.

From the docs: "If set to true, it persists authorization data and it would not be lost on browser close/refresh".https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

## Motivation and Context
Persists authorization data and it would not be lost on browser close/refresh.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
