### PR TITLE
Styles Safari scrollbars

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,12 +15,12 @@ html, body {
 }
 
 *::-webkit-scrollbar-thumb {
-  background-color: #c2c2c2;
+  background-color: rgba(0, 0, 0, 0.25);
   border-radius: 6px;
   border: 3px solid transparent;
   background-clip: padding-box;
 }
 
 *::-webkit-scrollbar-thumb:hover {
-  background-color: #7d7d7d;
+  background-color: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
The changes style the scrollbar in Safari to make it look like the standard scrollbar but without the background track. The scrollbar sometimes has that appearance already, and sometimes it doesn't. I can't find any rhyme or reason as to when it uses that appearance.

If anyone knows of a better way to address this, then I'm all ears. Until then, at least this makes Shape Docs' scrollbars look decent in Safari 😄

https://github.com/user-attachments/assets/5112f090-85c5-49a8-a6e3-6b1455fdd34b

