### PR TITLE
Use site name as a prefix for sign in texts

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -28,7 +28,7 @@ const InfoColumn = () => {
       bgcolor="#000"
       color="#fff"
     >
-      <SignInTexts />
+      <SignInTexts prefix={SITE_NAME} />
     </Box>
   )
 }

--- a/src/features/auth/view/SignInTexts.tsx
+++ b/src/features/auth/view/SignInTexts.tsx
@@ -3,7 +3,7 @@
 import { Box, Typography, SxProps } from "@mui/material"
 import { useEffect, useState, useMemo } from "react"
 
-const SignInTexts = () => {
+const SignInTexts = ({ prefix }: { prefix: string }) => {
   const getRandomTextColor = ({ excluding }: { excluding?: string }) => {
     const colors = ["#01BBFE", "#00AE47", "#FCB23D"]
       .filter(e => e !== excluding)
@@ -42,8 +42,9 @@ const SignInTexts = () => {
   return (
     <>
       <Box sx={{ position: "relative" }}>
-        <Text text={longestText} sx={{ visibility: "hidden" }} />
+        <Text prefix={prefix} text={longestText} sx={{ visibility: "hidden" }} />
         <Text
+          prefix={prefix}
           text={displayedText}
           textColor={textColor}
           sx={{ position: "absolute", top: 0, left: 0, right: 0 }}
@@ -69,11 +70,13 @@ const SignInTexts = () => {
 export default SignInTexts
 
 const Text = ({ 
+  prefix,
   text,
   textColor,
   children,
   sx
 }: {
+  prefix: string,
   text: string,
   textColor?: string,
   children?: React.ReactNode,
@@ -85,7 +88,7 @@ const Text = ({
       paddingLeft: { md: 5, lg: 10 },
       paddingRight: { md: 5, lg: 10 }
     }}>
-      Shape Docs <span style={{ color: textColor }}>{text}</span>
+      {prefix} <span style={{ color: textColor }}>{text}</span>
       {children}
     </Typography>
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR replaces the hardcoded Shape Docs with site name as the prefix for the sign in texts to maintain the configurability of the app.

## Screenshots (if appropriate):
![Screenshot 2024-07-30 at 14 38 40](https://github.com/user-attachments/assets/5fb4c7b9-b006-4772-bf8b-1b0e26b2daab)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)