### PR TITLE
Adds padding to bottom of Swagger

### DIFF
--- a/src/features/docs/view/Swagger.tsx
+++ b/src/features/docs/view/Swagger.tsx
@@ -1,13 +1,16 @@
 import { useState } from "react"
 import SwaggerUI from "swagger-ui-react"
 import "swagger-ui-react/swagger-ui.css"
+import { Box } from "@mui/material"
 import LoadingWrapper from "./LoadingWrapper"
 
 const Swagger = ({ url }: { url: string }) => {
   const [isLoading, setLoading] = useState(true)
   return (
     <LoadingWrapper showLoadingIndicator={isLoading}>
-      <SwaggerUI url={url} onComplete={() => setLoading(false)} deepLinking persistAuthorization />
+      <Box sx={{ paddingBottom: 1 }}>
+        <SwaggerUI url={url} onComplete={() => setLoading(false)} deepLinking persistAuthorization />
+      </Box>
     </LoadingWrapper>
   )
 }


### PR DESCRIPTION
This adds a bit of padding at the bottom of the Swagger documentation, which it doesn't add on its own, and it feels a bit unnatural.