### PR TITLE
Fixes sidebar not full height

### DIFF
--- a/src/features/sidebar/view/internal/sidebar/Sidebar.tsx
+++ b/src/features/sidebar/view/internal/sidebar/Sidebar.tsx
@@ -35,7 +35,8 @@ const Sidebar = ({ children }: { children?: React.ReactNode }) => {
       <Header />
       <Box sx={{
         position: "relative",
-        overflow: "hidden"
+        overflow: "hidden",
+        height: "100%"
       }}>
         <Shadow
           sx={{ 


### PR DESCRIPTION
Fixes an issue where the sidebar was not full height if the project list wasn't long enough to span the entire height of the screen.

|Old|New|
|-|-|
|<img width="500" alt="old" src="https://github.com/user-attachments/assets/a15716cb-2129-41d6-9761-efeb0aae8c60">|<img width="500" alt="new" src="https://github.com/user-attachments/assets/f21ebbab-71af-4440-bbf5-399cde9427be">|
