### PR TITLE
Fix: Delays error messages until data is refreshed

### DIFF
--- a/src/app/(authed)/(project-doc)/[...slug]/layout.tsx
+++ b/src/app/(authed)/(project-doc)/[...slug]/layout.tsx
@@ -1,47 +1,33 @@
 "use client"
 
+import { useContext } from "react"
 import { Box, Stack } from "@mui/material"
 import { useTheme } from "@mui/material/styles"
 import TrailingToolbarItem from "@/features/projects/view/toolbar/TrailingToolbarItem"
 import MobileToolbar from "@/features/projects/view/toolbar/MobileToolbar"
 import { useProjectSelection } from "@/features/projects/data"
-import NotFound from "@/features/projects/view/NotFound"
-import dynamic from "next/dynamic"
+import { ProjectsContext } from "@/common"
 import SecondaryHeaderPlaceholder from "@/features/sidebar/view/SecondarySplitHeaderPlaceholder"
-
-const SecondarySplitHeader = dynamic(() => import("@/features/sidebar/view/SecondarySplitHeader"),
-  {
-    loading: () => <SecondaryHeaderPlaceholder />,
-    ssr: false,
-  }
-)
+import SecondarySplitHeader from "@/features/sidebar/view/SecondarySplitHeader"
 
 export default function Page({ children }: { children: React.ReactNode }) {
+  const { cached } = useContext(ProjectsContext)
   const { project } = useProjectSelection()
   const theme = useTheme()
   return (
     <Stack sx={{ height: "100%" }}>
-      {!project &&
-        <>
-          <SecondarySplitHeader>
-            <TrailingToolbarItem/>
-          </SecondarySplitHeader>
-          <main style={{ flexGrow: "1", overflowY: "auto" }}>
-            <NotFound />
-          </main>
-        </>
-      }
-      {project &&
-        <>
+      <>
+        {project &&
           <SecondarySplitHeader mobileToolbar={<MobileToolbar/>}>
             <TrailingToolbarItem/>
           </SecondarySplitHeader>
-          <Box sx={{ height: "0.5px", background: theme.palette.divider }} />
-          <main style={{ flexGrow: "1", overflowY: "auto" }}>
-            {children}
-          </main>
-        </>
-      }
+        }
+        {!project && cached && <SecondaryHeaderPlaceholder/>}
+        <Box sx={{ height: "0.5px", background: theme.palette.divider }} />
+        <main style={{ flexGrow: "1", overflowY: "auto" }}>
+          {children}
+        </main>
+      </>
     </Stack>
   )
 }

--- a/src/app/(authed)/(project-doc)/[...slug]/layout.tsx
+++ b/src/app/(authed)/(project-doc)/[...slug]/layout.tsx
@@ -4,36 +4,33 @@ import { Box, Stack } from "@mui/material"
 import { useTheme } from "@mui/material/styles"
 import TrailingToolbarItem from "@/features/projects/view/toolbar/TrailingToolbarItem"
 import MobileToolbar from "@/features/projects/view/toolbar/MobileToolbar"
-import { useProjectSelection } from "@/features/projects/data"
 import SecondaryHeaderPlaceholder from "@/features/sidebar/view/SecondarySplitHeaderPlaceholder"
-import SecondarySplitHeader from "@/features/sidebar/view/SecondarySplitHeader"
 import { useContext } from "react"
 import { ProjectsContext } from "@/common"
 import LoadingIndicator from "@/common/ui/LoadingIndicator"
+import SecondarySplitHeader from "@/features/sidebar/view/SecondarySplitHeader"
 
 export default function Page({ children }: { children: React.ReactNode }) {
-  const { project } = useProjectSelection()
   const { refreshed } = useContext(ProjectsContext)
 
   const theme = useTheme()
   
   return (
     <Stack sx={{ height: "100%" }}>
-      {refreshed ? 
         <>
-          {project &&
+          {!refreshed ? <SecondaryHeaderPlaceholder/> :
             <SecondarySplitHeader mobileToolbar={<MobileToolbar/>}>
               <TrailingToolbarItem/>
             </SecondarySplitHeader>
           }
-          {!project && <SecondaryHeaderPlaceholder/>}
           <Box sx={{ height: "0.5px", background: theme.palette.divider }} />
-          <main style={{ flexGrow: "1", overflowY: "auto" }}>
-            {children}
-          </main>
+          {refreshed ? 
+            <main style={{ flexGrow: "1", overflowY: "auto" }}>
+              {children}
+            </main> : 
+            <LoadingIndicator />
+          }
         </>
-      : <LoadingIndicator />
-    }
     </Stack>
   )
 }

--- a/src/app/(authed)/(project-doc)/[...slug]/layout.tsx
+++ b/src/app/(authed)/(project-doc)/[...slug]/layout.tsx
@@ -1,33 +1,39 @@
 "use client"
 
-import { useContext } from "react"
 import { Box, Stack } from "@mui/material"
 import { useTheme } from "@mui/material/styles"
 import TrailingToolbarItem from "@/features/projects/view/toolbar/TrailingToolbarItem"
 import MobileToolbar from "@/features/projects/view/toolbar/MobileToolbar"
 import { useProjectSelection } from "@/features/projects/data"
-import { ProjectsContext } from "@/common"
 import SecondaryHeaderPlaceholder from "@/features/sidebar/view/SecondarySplitHeaderPlaceholder"
 import SecondarySplitHeader from "@/features/sidebar/view/SecondarySplitHeader"
+import { useContext } from "react"
+import { ProjectsContext } from "@/common"
+import LoadingIndicator from "@/common/ui/LoadingIndicator"
 
 export default function Page({ children }: { children: React.ReactNode }) {
-  const { cached } = useContext(ProjectsContext)
   const { project } = useProjectSelection()
+  const { refreshed } = useContext(ProjectsContext)
+
   const theme = useTheme()
+  
   return (
     <Stack sx={{ height: "100%" }}>
-      <>
-        {project &&
-          <SecondarySplitHeader mobileToolbar={<MobileToolbar/>}>
-            <TrailingToolbarItem/>
-          </SecondarySplitHeader>
-        }
-        {!project && cached && <SecondaryHeaderPlaceholder/>}
-        <Box sx={{ height: "0.5px", background: theme.palette.divider }} />
-        <main style={{ flexGrow: "1", overflowY: "auto" }}>
-          {children}
-        </main>
-      </>
+      {refreshed ? 
+        <>
+          {project &&
+            <SecondarySplitHeader mobileToolbar={<MobileToolbar/>}>
+              <TrailingToolbarItem/>
+            </SecondarySplitHeader>
+          }
+          {!project && <SecondaryHeaderPlaceholder/>}
+          <Box sx={{ height: "0.5px", background: theme.palette.divider }} />
+          <main style={{ flexGrow: "1", overflowY: "auto" }}>
+            {children}
+          </main>
+        </>
+      : <LoadingIndicator />
+    }
     </Stack>
   )
 }

--- a/src/app/(authed)/(project-doc)/[...slug]/page.tsx
+++ b/src/app/(authed)/(project-doc)/[...slug]/page.tsx
@@ -1,12 +1,15 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useContext } from "react"
 import ErrorMessage from "@/common/ui/ErrorMessage"
 import { updateWindowTitle } from "@/features/projects/domain"
 import { useProjectSelection } from "@/features/projects/data"
 import Documentation from "@/features/projects/view/Documentation"
+import NotFound from "@/features/projects/view/NotFound"
+import { ProjectsContext } from "@/common"
 
 export default function Page() {
+  const { cached } = useContext(ProjectsContext)
   const { project, version, specification, navigateToSelectionIfNeeded } = useProjectSelection()
   // Ensure the URL reflects the current selection of project, version, and specification.
   useEffect(() => {
@@ -28,12 +31,13 @@ export default function Page() {
       {project && version && specification &&
         <Documentation url={specification.url} />
       }
-      {project && !version &&
+      {project && !version && !cached &&
         <ErrorMessage text="The selected branch or tag was not found."/>
       }
-      {project && !specification &&
+      {project && !specification && !cached &&
         <ErrorMessage text="The selected specification was not found."/>
       }
+      {!project && !cached && <NotFound/>}
     </>
   )
 }

--- a/src/app/(authed)/(project-doc)/[...slug]/page.tsx
+++ b/src/app/(authed)/(project-doc)/[...slug]/page.tsx
@@ -1,15 +1,13 @@
 "use client"
 
-import { useEffect, useContext } from "react"
+import { useEffect } from "react"
 import ErrorMessage from "@/common/ui/ErrorMessage"
 import { updateWindowTitle } from "@/features/projects/domain"
 import { useProjectSelection } from "@/features/projects/data"
 import Documentation from "@/features/projects/view/Documentation"
 import NotFound from "@/features/projects/view/NotFound"
-import { ProjectsContext } from "@/common"
 
 export default function Page() {
-  const { cached } = useContext(ProjectsContext)
   const { project, version, specification, navigateToSelectionIfNeeded } = useProjectSelection()
   // Ensure the URL reflects the current selection of project, version, and specification.
   useEffect(() => {
@@ -26,18 +24,19 @@ export default function Page() {
       specification
     })
   }, [project, version, specification])
+
   return (
     <>
       {project && version && specification &&
         <Documentation url={specification.url} />
       }
-      {project && !version && !cached &&
+      {project && !version &&
         <ErrorMessage text="The selected branch or tag was not found."/>
       }
-      {project && !specification && !cached &&
+      {project && !specification &&
         <ErrorMessage text="The selected specification was not found."/>
       }
-      {!project && !cached && <NotFound/>}
+      {!project && <NotFound/>}
     </>
   )
 }

--- a/src/app/(authed)/(project-doc)/[...slug]/page.tsx
+++ b/src/app/(authed)/(project-doc)/[...slug]/page.tsx
@@ -30,11 +30,8 @@ export default function Page() {
       {project && version && specification &&
         <Documentation url={specification.url} />
       }
-      {project && !version &&
-        <ErrorMessage text="The selected branch or tag was not found."/>
-      }
-      {project && !specification &&
-        <ErrorMessage text="The selected specification was not found."/>
+      {project && (!version || !specification) &&
+        <ErrorMessage text={`The selected ${!version ? "branch or tag" : "specification"} was not found.`}/>
       }
       {!project && <NotFound/>}
     </>

--- a/src/common/context/ProjectsContext.ts
+++ b/src/common/context/ProjectsContext.ts
@@ -6,11 +6,13 @@ import { Project } from "@/features/projects/domain"
 export const SidebarTogglableContext = createContext<boolean>(true)
 
 type ProjectsContextValue = {
+  cached: boolean,
   projects: Project[],
   setProjects: (projects: Project[]) => void
 }
 
 export const ProjectsContext = createContext<ProjectsContextValue>({
+  cached: true,
   projects: [],
   setProjects: () => {}
 })

--- a/src/common/context/ProjectsContext.ts
+++ b/src/common/context/ProjectsContext.ts
@@ -6,13 +6,13 @@ import { Project } from "@/features/projects/domain"
 export const SidebarTogglableContext = createContext<boolean>(true)
 
 type ProjectsContextValue = {
-  cached: boolean,
+  refreshed: boolean,
   projects: Project[],
   setProjects: (projects: Project[]) => void
 }
 
 export const ProjectsContext = createContext<ProjectsContextValue>({
-  cached: true,
+  refreshed: false,
   projects: [],
   setProjects: () => {}
 })

--- a/src/features/projects/view/ProjectsContextProvider.tsx
+++ b/src/features/projects/view/ProjectsContextProvider.tsx
@@ -11,17 +11,19 @@ const ProjectsContextProvider = ({
   initialProjects?: Project[],
   children?: React.ReactNode
 }) => {
-  const [cached, setCached] = useState<boolean>(true)
+  const [refreshed, setRefreshed] = useState<boolean>(false)
   const [projects, setProjects] = useState<Project[]>(initialProjects || [])
-  const setProjectsAndCached = (projects: Project[]) => {
-    setProjects(projects)
-    setCached(false)
+
+  const setProjectsAndRefreshed = (value: Project[]) => {
+    setProjects(value)
+    // Only set refreshed to true after projects are updated
+    if (JSON.stringify(projects) !== JSON.stringify(value)) setRefreshed(true)
   }
   return (
     <ProjectsContext.Provider value={{
-      cached,
+      refreshed,
       projects,
-      setProjects: setProjectsAndCached
+      setProjects: setProjectsAndRefreshed
     }}>
       {children}
     </ProjectsContext.Provider>

--- a/src/features/projects/view/ProjectsContextProvider.tsx
+++ b/src/features/projects/view/ProjectsContextProvider.tsx
@@ -11,9 +11,18 @@ const ProjectsContextProvider = ({
   initialProjects?: Project[],
   children?: React.ReactNode
 }) => {
+  const [cached, setCached] = useState<boolean>(true)
   const [projects, setProjects] = useState<Project[]>(initialProjects || [])
+  const setProjectsAndCached = (projects: Project[]) => {
+    setProjects(projects)
+    setCached(false)
+  }
   return (
-    <ProjectsContext.Provider value={{ projects, setProjects }}>
+    <ProjectsContext.Provider value={{
+      cached,
+      projects,
+      setProjects: setProjectsAndCached
+    }}>
       {children}
     </ProjectsContext.Provider>
   )

--- a/src/features/projects/view/ProjectsContextProvider.tsx
+++ b/src/features/projects/view/ProjectsContextProvider.tsx
@@ -14,10 +14,16 @@ const ProjectsContextProvider = ({
   const [refreshed, setRefreshed] = useState<boolean>(false)
   const [projects, setProjects] = useState<Project[]>(initialProjects || [])
 
+  const hasProjectChanged = (value: Project[]) => value.some((project, index) => {
+    // Compare by project id and version (or any other key fields)
+    return project.id !== projects[index]?.id || project.versions !== projects[index]?.versions
+  })
+
   const setProjectsAndRefreshed = (value: Project[]) => {
     setProjects(value)
-    // Only set refreshed to true after projects are updated
-    if (JSON.stringify(projects) !== JSON.stringify(value)) setRefreshed(true)
+    // If any project has changed, update the state and mark as refreshed
+    if (hasProjectChanged(value)) setRefreshed(true)
+
   }
   return (
     <ProjectsContext.Provider value={{


### PR DESCRIPTION
This PR resolves the issue of outdated or inconsistent project data being displayed when loading a project’s details. Previously, error messages such as "Page not found" or "The selected branch or tag was not found" would appear prematurely while data was still being refreshed. The new approach introduces a refreshed state, ensuring that the loading screen remains until the updated project data is fully available.

Additionally, we've added logic to compare new project data with the existing one using deep equality checks to prevent unnecessary updates, further improving performance and reliability.

### Loading screens

<img width="1786" alt="Screenshot 2024-10-07 at 15 36 15" src="https://github.com/user-attachments/assets/33e37d70-7acd-49b8-ba7f-eb68ad0df205">
<img width="1786" alt="Screenshot 2024-10-07 at 15 36 05" src="https://github.com/user-attachments/assets/bdfc2602-813e-435a-8202-17047c295181">
<img width="1786" alt="Screenshot 2024-10-07 at 15 35 40" src="https://github.com/user-attachments/assets/ac365a4f-3aac-4abf-bbd4-c45215bd18e2">
<img width="1786" alt="Screenshot 2024-10-07 at 15 35 07" src="https://github.com/user-attachments/assets/8d225db9-6c9b-4995-b05f-d3bc10110082">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
