### PR TITLE
Add support for spaces in specification filenames

### DIFF
--- a/__test__/projects/getProjectSelectionFromPath.test.ts
+++ b/__test__/projects/getProjectSelectionFromPath.test.ts
@@ -288,3 +288,69 @@ test("It moves specification ID to version ID if needed", () => {
   expect(sut.version!.id).toEqual("bar/baz")
   expect(sut.specification!.id).toEqual("hello")
 })
+
+test("It supports specifications with spaces in their names", () => {
+  const sut = getProjectSelectionFromPath({
+    path: "/acme/foo/main/openapi with spaces.yml",
+    projects: [
+      {
+        id: 'acme-foo',
+        name: 'foo',
+        displayName: "Ulrik's Playground",
+        versions: [{
+          id: 'main',
+          name: 'main',
+          specifications: [{
+            id: "openapi with spaces.yml", 
+            name: "openapi with spaces.yml", 
+            url: "/api/blob/acme/foo-openapi/openapi with spaces.yml?ref=3dbafacbe57ac931ee750fc973bad3c81c9765bb", 
+            editURL: "https://github.com/acme/foo-openapi/edit/main/openapi with spaces.yml"
+          }],
+          url: 'https://github.com/acme/foo-openapi/tree/main',
+          isDefault: true
+        }],
+        imageURL: '/api/blob/acme/foo-openapi/icon.png?ref=3dbafacbe57ac931ee750fc973bad3c81c9765bb',
+        url: 'https://github.com/acme/foo-openapi',
+        owner: 'acme',
+        ownerUrl: 'https://github.com/acme'
+      }
+    ]
+  })
+  expect(sut.project!.owner).toEqual("acme")
+  expect(sut.project!.name).toEqual("foo")
+  expect(sut.version!.id).toEqual("main")
+  expect(sut.specification!.id).toEqual("openapi with spaces.yml")
+})
+
+test("It supports specifications with URL-encoded spaces in their names", () => {
+  const sut = getProjectSelectionFromPath({
+    path: "/acme/foo/main/openapi%20with%20spaces.yml",
+    projects: [
+      {
+        id: 'acme-foo',
+        name: 'foo',
+        displayName: "Ulrik's Playground",
+        versions: [{
+          id: 'main',
+          name: 'main',
+          specifications: [{
+            id: "openapi with spaces.yml", 
+            name: "openapi with spaces.yml", 
+            url: "/api/blob/acme/foo-openapi/openapi with spaces.yml?ref=3dbafacbe57ac931ee750fc973bad3c81c9765bb", 
+            editURL: "https://github.com/acme/foo-openapi/edit/main/openapi with spaces.yml"
+          }],
+          url: 'https://github.com/acme/foo-openapi/tree/main',
+          isDefault: true
+        }],
+        imageURL: '/api/blob/acme/foo-openapi/icon.png?ref=3dbafacbe57ac931ee750fc973bad3c81c9765bb',
+        url: 'https://github.com/acme/foo-openapi',
+        owner: 'acme',
+        ownerUrl: 'https://github.com/acme'
+      }
+    ]
+  })
+  expect(sut.project!.owner).toEqual("acme")
+  expect(sut.project!.name).toEqual("foo")
+  expect(sut.version!.id).toEqual("main")
+  expect(sut.specification!.id).toEqual("openapi with spaces.yml")
+})

--- a/src/features/projects/domain/getProjectSelectionFromPath.ts
+++ b/src/features/projects/domain/getProjectSelectionFromPath.ts
@@ -16,6 +16,7 @@ export default function getProjectSelectionFromPath({
   if (path.startsWith("/")) {
     path = path.substring(1)
   }
+  path = decodeURIComponent(path)
   const { owner: _owner, projectName: _projectName, versionId, specificationId } = guessSelection(path)
   // If no project is selected and the user only has a single project then we select that.
   let owner = _owner


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds support for loading specifications that contains spaces (and other special chars) as part of the filename.

A URLDecode is performed on the pathname (e.g. `/acmeorg/foo/main/openapi%20with%20spaces.yml`) to make sure we are able to find the file in GitHub.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently Framna Docs will display that "The selected specification was not found." although the file actually exists in the repository.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
