### PR TITLE
Makes SecondaryHeaderPlaceholder full width

### DIFF
--- a/src/features/sidebar/view/SecondarySplitHeaderPlaceholder.tsx
+++ b/src/features/sidebar/view/SecondarySplitHeaderPlaceholder.tsx
@@ -12,7 +12,6 @@ const SecondaryHeaderPlaceholder = () => {
           alignItems: "center",
           padding: 2,
           paddingLeft: { xs: 4, md: 2 },
-          maxWidth: "1460px",
           margin: "auto",
           height: 64,
         }}


### PR DESCRIPTION
The PR fixes an issue where SecondaryHeaderPlaceholder did not fill the entire width.

![Screenshot 2024-10-18 at 13 15 26](https://github.com/user-attachments/assets/55565b9f-6692-4c53-97c5-3901a968c663)
