### PR TITLE
Respond with text/plain from /api/proxy and /api/blob

### DIFF
--- a/__test__/common/github/RepoRestrictedGitHubClient.test.ts
+++ b/__test__/common/github/RepoRestrictedGitHubClient.test.ts
@@ -7,7 +7,6 @@ import {
     GetRepositoryContentRequest,
     GraphQLQueryRequest,
     UpdatePullRequestCommentRequest,
-    GitHubClient
 } from "@/common";
 import { jest } from '@jest/globals';
 
@@ -37,7 +36,7 @@ describe('RepoRestrictedGitHubClient', () => {
         expect(gitHubClient.graphql).toHaveBeenCalledWith(request);
     });
 
-    it('should check suffix for getRepositoryContent', async () => {
+    it('should delegate getRepositoryContent to the underlying client', async () => {
         const request: GetRepositoryContentRequest = {
             repositoryName: 'repo-suffix', path: '',
             repositoryOwner: '',
@@ -56,7 +55,7 @@ describe('RepoRestrictedGitHubClient', () => {
         await expect(client.getRepositoryContent(request)).rejects.toThrow("Invalid repository name");
     });
 
-    it('should check suffix for getPullRequestFiles', async () => {
+    it('should delegate getPullRequestFiles to the underlying client', async () => {
         const request: GetPullRequestFilesRequest = {
             repositoryName: 'repo-suffix', pullRequestNumber: 1,
             appInstallationId: 0,
@@ -75,7 +74,7 @@ describe('RepoRestrictedGitHubClient', () => {
         await expect(client.getPullRequestFiles(request)).rejects.toThrow("Invalid repository name");
     });
 
-    it('should check suffix for getPullRequestComments', async () => {
+    it('should delegate getPullRequestComments to the underlying client', async () => {
         const request: GetPullRequestCommentsRequest = {
             repositoryName: 'repo-suffix', pullRequestNumber: 1,
             appInstallationId: 0,
@@ -94,7 +93,7 @@ describe('RepoRestrictedGitHubClient', () => {
         await expect(client.getPullRequestComments(request)).rejects.toThrow("Invalid repository name");
     });
 
-    it('should check suffix for addCommentToPullRequest', async () => {
+    it('should delegate addCommentToPullRequest to the underlying client', async () => {
         const request: AddCommentToPullRequestRequest = {
             repositoryName: 'repo-suffix', pullRequestNumber: 1, body: '',
             appInstallationId: 0,
@@ -113,7 +112,7 @@ describe('RepoRestrictedGitHubClient', () => {
         await expect(client.addCommentToPullRequest(request)).rejects.toThrow("Invalid repository name");
     });
 
-    it('should check suffix for updatePullRequestComment', async () => {
+    it('should delegate updatePullRequestComment to the underlying client', async () => {
         const request: UpdatePullRequestCommentRequest = {
             repositoryName: 'repo-suffix', commentId: 1, body: '',
             appInstallationId: 0,

--- a/src/app/api/blob/[owner]/[repository]/[...path]/route.ts
+++ b/src/app/api/blob/[owner]/[repository]/[...path]/route.ts
@@ -28,6 +28,8 @@ export async function GET(req: NextRequest, { params }: { params: GetBlobParams 
     const cacheExpirationInSeconds = 60 * 60 * 24 * 30 // 30 days
     headers.set("Content-Type", "image/*");
     headers.set("Cache-Control", `max-age=${cacheExpirationInSeconds}`)
+  } else {
+    headers.set("Content-Type", "text/plain");
   }
   return new NextResponse(file, { status: 200, headers })
 }

--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -30,7 +30,7 @@ export async function GET(req: NextRequest) {
     const maxBytes = maxMegabytes * 1024 * 1024
     const fileText = await downloadFile({ url, maxBytes, timeoutInSeconds })
     checkIfJsonOrYaml(fileText)
-    return new NextResponse(fileText, { status: 200 })
+    return new NextResponse(fileText, { status: 200, headers: { "Content-Type": "text/plain" } })
   } catch (error) {
     if (error instanceof Error == false) {
       return makeAPIErrorResponse(500, "An unknown error occurred.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With this change the /api/proxy endpoint (which allows loading files from external URLs) will always respond `Content-Type: text/plain`. This is an extra layer of security (in addition to #417) to safeguard against serving HTML from the proxy endpoint which could be used for an XSS attack.

Furthermore the `/api/blob` endpoint (which is used for loading files from the repositories) will return `text/plain` unless the files in an image, in which case it will return `image/*`. GitHub already returns files in plain text even if they are .html, but we might as well be on the safe side.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

NextResponse (underlying Response) will attempt to auto detect the content type based on the passed blob. With this change the auto detection is disabled and we always set the content type. It does not change functionality but it adds an extra safeguard to ensure we never return HTML/JavaScript from the proxy endpoint.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
