### PR TITLE
Remove problematic customization of session callback

### DIFF
--- a/src/composition.ts
+++ b/src/composition.ts
@@ -110,8 +110,18 @@ export const { signIn, auth, handlers: authHandlers } = NextAuth({
       return await logInHandler.handleLogIn({ user, account })
     },
     async session({ session, user }) {
-      session.user.id = user.id
-      return session
+      // Construct a new session object conforming to DefaultSession
+      // If "session" is returned it will include everything from AdapterSession,
+      // which is critical as this contains the sessionToken
+      return {
+        user: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          image: user.image
+        },
+        expires: session.expires,
+      }
     }
   }
 })


### PR DESCRIPTION
## Description
This PR fixes the customization on the Authjs session callback.

The customization was suppose to only add `id` to the `user` object of the session callback response (exposed via `/api/auth/session`), but when the previous customization, the callback also started returning otherwise secret information - namely the "sessionToken". **This is _really_ unexpected and poses a security risk.**

It is especially a problem because the session token is suppose to only be stored in an `HttpOnly` cookie in the browser and on the server side (database), making it inaccessible to JavaScript. But with the `/api/auth/session` endpoint returning the session token it is easily accessible from JavaScript by doing a network request.

Reading the session token from JavaScript is problematic because it can be used as part of a session hijacking attack using XSS.

With this fix the session object is explicitly constructed to follow the `DefaultSession` ([source](https://github.com/nextauthjs/next-auth/blob/a1cf4069661fd290d9217d28bc008228a7544995/packages/core/src/types.ts#L243)) with only the `user.id` added.

## Motivation and Context
With this seemingly innocent modification to the session callback (which is clearly documented in [Authjs documentation](https://authjs.dev/guides/extending-the-session#with-database)) 
```javascript
callbacks: {
  session({ session, user }) {
    session.user.id = user.id
    return session
  },
}
```

the `GET /api/auth/session` endpoint starts returning a lot more session information:

```json
{
    "id": 27,
    "userId": 5,
    "expires": "2024-12-06T04:43:00.371Z",
    "sessionToken": "abcdefg-4fb0-4145-9787-421e3465bc49", <---- !!!
    "user": {
        "id": 5,
        "name": "Firstname Lastname",
        "email": null,
        "emailVerified": null,
        "image": "https://avatars.githubusercontent.com/u/114411111?v=4"
    }
}
```

Without the modification the response looks like this (which is safe and expected):

```json
{
    "user": {
        "name": "Firstname Lastname",
        "email": null,
        "image": "https://avatars.githubusercontent.com/u/114411111?v=4"
    },
    "expires": "2024-12-06T04:43:00.371Z"
}
```

The root cause is likely that with the modification the callback starts returning `AdapterSession` ([source](https://github.com/nextauthjs/next-auth/blob/a1cf4069661fd290d9217d28bc008228a7544995/packages/core/src/adapters.ts#L213)) instead of `Default Session` ([source](https://github.com/nextauthjs/next-auth/blob/a1cf4069661fd290d9217d28bc008228a7544995/packages/core/src/types.ts#L243)).

With this PR only the `user.id` and  property is added:

```json
{
    "user": {
        "id": 5,
        "email": null,
        "name": "Firstname Lastname",
        "image": "https://avatars.githubusercontent.com/u/114411111?v=4"
    },
    "expires": "2024-12-06T04:43:00.371Z"
}
```

## Screenshots (if appropriate):
From the Authjs documentation (https://authjs.dev/guides/extending-the-session#with-database).
![Screenshot 2024-11-06 at 11 07 38](https://github.com/user-attachments/assets/5fca0536-b40a-4d9e-9e2a-ba8a0d5965f2)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
