### PR TITLE
Truncates links to specifications in Swagger UI

### DIFF
--- a/src/features/docs/view/Swagger.tsx
+++ b/src/features/docs/view/Swagger.tsx
@@ -3,6 +3,7 @@ import SwaggerUI from "swagger-ui-react"
 import "swagger-ui-react/swagger-ui.css"
 import { Box } from "@mui/material"
 import LoadingWrapper from "./LoadingWrapper"
+import "./swagger.css"
 
 const Swagger = ({ url }: { url: string }) => {
   const [isLoading, setLoading] = useState(true)

--- a/src/features/docs/view/swagger.css
+++ b/src/features/docs/view/swagger.css
@@ -1,0 +1,6 @@
+.swagger-ui .info span.url {
+  display: block;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 80%;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Truncates links to specifications in Swagger to ensure the viewport doens't become scrollable when links are long.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

![Screenshot 2024-12-04 at 15 16 41@2x](https://github.com/user-attachments/assets/9c2259a7-0b69-45d4-b2ee-86e35920838d)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
