### PR TITLE
Include debug info when failing to load remote spec

### DIFF
--- a/src/app/api/remotes/[encodedRemoteConfig]/route.ts
+++ b/src/app/api/remotes/[encodedRemoteConfig]/route.ts
@@ -55,7 +55,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<Remot
     } else if (error.name === ErrorName.TIMEOUT) {
       return makeAPIErrorResponse(408, "The operation timed out.")
     } else if (error.name === ErrorName.NOT_JSON_OR_YAML) {
-      return makeAPIErrorResponse(400, "Url does not point to a JSON or YAML file.")
+      return makeAPIErrorResponse(400, error.message)
     } else if (error.name === ErrorName.URL_MAY_NOT_INCLUDE_BASIC_AITH) {
       return makeAPIErrorResponse(400, "Url may not include basic auth.")
     } else {

--- a/src/common/utils/fileUtils.ts
+++ b/src/common/utils/fileUtils.ts
@@ -66,7 +66,7 @@ export function checkIfJsonOrYaml(fileText: string) {
     try {
         parseYaml(fileText) // will also parse JSON as it is a subset of YAML
     } catch {
-        const error = new Error("File is not JSON or YAML")
+        const error = new Error("File is not JSON or YAML. Content: " + fileText.slice(0, 1000));
         error.name = ErrorName.NOT_JSON_OR_YAML
         throw error
     }

--- a/src/features/projects/data/GitHubProjectDataSource.ts
+++ b/src/features/projects/data/GitHubProjectDataSource.ts
@@ -242,7 +242,7 @@ export default class GitHubProjectDataSource implements IProjectDataSource {
         password: this.encryptionService.decrypt(projectConfigRemoteSpec.auth.encryptedPassword)
       }
     } catch (error) {
-      console.error(`Failed to decrypt remote specification auth for ${projectConfigRemoteSpec.url}. Perhaps a different public key was used?:`, error);
+      console.info(`Failed to decrypt remote specification auth for ${projectConfigRemoteSpec.name} (${projectConfigRemoteSpec.url}). Perhaps a different public key was used?:`, error);
       return undefined
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to improve the debug experience when loading remote specification fails by:

1. Including part of remote spec content in error response from `/remote` endpoint. Makes it easier to debug why loading a remote spec fails.
2. Include remote spec name in the error message when decryption fails (`Failed to decrypt remote specification auth for framna-docs-local (https://ws.fk.dk/dev/omdeler/api-docs). Perhaps a different public key was used?`). Makes it easier to see which remote spec is failing.

Also the log level of 2. is changed to reflect that it is an expected error (e.g. wrong encryption key used).

## Screenshots (if appropriate):
<img width="1286" alt="Screenshot 2025-02-06 at 09 00 07" src="https://github.com/user-attachments/assets/17f9a314-5fce-4a1a-b897-f116a053d3f2" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
