### PR TITLE
Group all Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,6 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      fontawesome:
+      all:
         patterns:
-          - "@fortawesome/*"
-      octokit:
-        patterns:
-          - "@octokit/*"
-      mui:
-        patterns:
-          - "@mui/*"
-      typescript-eslint:
-        patterns:
-          - "@typescript-eslint/*"
+          - "*"


### PR DESCRIPTION
Reconfigures Dependabot to group all updates, meaning that it will open fewer PRs.