### PR TITLE
Sets jsx to preserve

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
Next.js automatically modifies tsconfig.json to set `jsx` to `preserve` when doing `npm run build`, as shown below. This PR adds the change to version control.

```bash
❯ npm run build

> framna-docs@1.0.0 build
> next build

   ▲ Next.js 15.5.6
   - Environments: .env

   Creating an optimized production build ...
 ✓ Compiled successfully in 2.8s
   Skipping linting
   Checking validity of types  .
   We detected TypeScript in your project and reconfigured your tsconfig.json file for you.
   The following mandatory changes were made to your tsconfig.json:

        - jsx was set to preserve (next.js implements its own optimized jsx transform)
```