### PR TITLE
Fixes plus icon in New Project button not centered

### DIFF
--- a/src/features/sidebar/view/internal/sidebar/NewProjectButton.tsx
+++ b/src/features/sidebar/view/internal/sidebar/NewProjectButton.tsx
@@ -24,7 +24,11 @@ const NewProjectButton = () => {
             height={40}
             sx={{ background: "#dfdfdf" }}
           >
-            <Stack sx={{ height: "100%" }} justifyContent="center">
+            <Stack
+              sx={{ height: "100%" }}
+              justifyContent="center"
+              alignItems="center"
+            >
               <FontAwesomeIcon icon={faPlus} size="lg" color="#bababa" />
             </Stack>
           </ProjectAvatarSquircle>


### PR DESCRIPTION
Fixes an issue where the plus icon in the New Project button was not centered.

## Screenshots (if appropriate):

|Old|New|
|-|-|
|<img width="604" height="250" alt="Screenshot 2025-11-18 at 07 17 31@2x" src="https://github.com/user-attachments/assets/881691f1-256f-4dac-b740-6f95dad35626" />|<img width="600" height="264" alt="Screenshot 2025-11-18 at 07 16 31@2x" src="https://github.com/user-attachments/assets/0c5d99fa-9b7a-484d-9913-58ff5ce835a3" />|

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
