### PR TITLE
Upgrade to GitHub REST API version 2026-03-10

### DIFF
--- a/src/common/github/GitHubClient.ts
+++ b/src/common/github/GitHubClient.ts
@@ -47,7 +47,7 @@ export default class GitHubClient implements IGitHubClient {
   }
   
   private makeOctokit(auth: string): Octokit {
-    return new Octokit({ auth, headers: { "X-GitHub-Api-Version": "2022-11-28" } })
+    return new Octokit({ auth, request: { headers: { "X-GitHub-Api-Version": "2022-11-28" } } })
   }
 
   async graphql(request: GraphQLQueryRequest): Promise<GraphQlQueryResponse> {

--- a/src/common/github/GitHubClient.ts
+++ b/src/common/github/GitHubClient.ts
@@ -15,6 +15,8 @@ import IGitHubClient, {
   PullRequestFile
 } from "./IGitHubClient"
 
+const GITHUB_API_VERSION = { "X-GitHub-Api-Version": "2022-11-28" } as const
+
 interface IGitHubOAuthTokenDataSource {
   getOAuthToken(): Promise<{ accessToken: string }>
 }
@@ -26,7 +28,7 @@ type InstallationAuthenticator = (installationId: number) => Promise<{token: str
 export default class GitHubClient implements IGitHubClient {
   private readonly oauthTokenDataSource: IGitHubOAuthTokenDataSource
   private readonly installationAuthenticator: InstallationAuthenticator
-  
+
   constructor(config: {
     appId: string
     clientId: string
@@ -45,25 +47,22 @@ export default class GitHubClient implements IGitHubClient {
       return await appAuth({ type: "installation", installationId })
     }
   }
-  
-  private makeOctokit(auth: string): Octokit {
-    return new Octokit({ auth, request: { headers: { "X-GitHub-Api-Version": "2022-11-28" } } })
-  }
 
   async graphql(request: GraphQLQueryRequest): Promise<GraphQlQueryResponse> {
     const oauthToken = await this.oauthTokenDataSource.getOAuthToken()
-    const octokit = this.makeOctokit(oauthToken.accessToken)
+    const octokit = new Octokit({ auth: oauthToken.accessToken })
     return await octokit.graphql(request.query, request.variables)
   }
 
   async getRepositoryContent(request: GetRepositoryContentRequest): Promise<RepositoryContent> {
     const oauthToken = await this.oauthTokenDataSource.getOAuthToken()
-    const octokit = this.makeOctokit(oauthToken.accessToken)
+    const octokit = new Octokit({ auth: oauthToken.accessToken })
     const response = await octokit.rest.repos.getContent({
       owner: request.repositoryOwner,
       repo: request.repositoryName,
       path: request.path,
-      ref: request.ref
+      ref: request.ref,
+      headers: GITHUB_API_VERSION
     })
     const item = response.data as GitHubContentItem
     return { downloadURL: item.download_url }
@@ -71,11 +70,12 @@ export default class GitHubClient implements IGitHubClient {
 
   async getPullRequestFiles(request: GetPullRequestFilesRequest): Promise<PullRequestFile[]> {
     const auth = await this.installationAuthenticator(request.appInstallationId)
-    const octokit = this.makeOctokit(auth.token)
+    const octokit = new Octokit({ auth: auth.token })
     const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
       owner: request.repositoryOwner,
       repo: request.repositoryName,
       pull_number: request.pullRequestNumber,
+      headers: GITHUB_API_VERSION
     })
     return files.map(file => {
       return { filename: file.filename, status: file.status }
@@ -84,11 +84,12 @@ export default class GitHubClient implements IGitHubClient {
 
   async getPullRequestComments(request: GetPullRequestCommentsRequest): Promise<PullRequestComment[]> {
     const auth = await this.installationAuthenticator(request.appInstallationId)
-    const octokit = this.makeOctokit(auth.token)
+    const octokit = new Octokit({ auth: auth.token })
     const comments = await octokit.paginate(octokit.rest.issues.listComments, {
       owner: request.repositoryOwner,
       repo: request.repositoryName,
       issue_number: request.pullRequestNumber,
+      headers: GITHUB_API_VERSION
     })
     const result: PullRequestComment[] = []
     for await (const comment of comments) {
@@ -106,33 +107,36 @@ export default class GitHubClient implements IGitHubClient {
 
   async addCommentToPullRequest(request: AddCommentToPullRequestRequest): Promise<void> {
     const auth = await this.installationAuthenticator(request.appInstallationId)
-    const octokit = this.makeOctokit(auth.token)
+    const octokit = new Octokit({ auth: auth.token })
     await octokit.rest.issues.createComment({
       owner: request.repositoryOwner,
       repo: request.repositoryName,
       issue_number: request.pullRequestNumber,
-      body: request.body
+      body: request.body,
+      headers: GITHUB_API_VERSION
     })
   }
 
   async updatePullRequestComment(request: UpdatePullRequestCommentRequest): Promise<void> {
     const auth = await this.installationAuthenticator(request.appInstallationId)
-    const octokit = this.makeOctokit(auth.token)
+    const octokit = new Octokit({ auth: auth.token })
     await octokit.rest.issues.updateComment({
       comment_id: request.commentId,
       owner: request.repositoryOwner,
       repo: request.repositoryName,
-      body: request.body
+      body: request.body,
+      headers: GITHUB_API_VERSION
     })
   }
 
   async compareCommitsWithBasehead(request: CompareCommitsRequest): Promise<CompareCommitsResponse> {
     const oauthToken = await this.oauthTokenDataSource.getOAuthToken()
-    const octokit = this.makeOctokit(oauthToken.accessToken)
+    const octokit = new Octokit({ auth: oauthToken.accessToken })
     const response = await octokit.rest.repos.compareCommitsWithBasehead({
       owner: request.repositoryOwner,
       repo: request.repositoryName,
-      basehead: `${request.baseRefOid}...${request.headRefOid}`
+      basehead: `${request.baseRefOid}...${request.headRefOid}`,
+      headers: GITHUB_API_VERSION
     })
     return { mergeBaseSha: response.data.merge_base_commit.sha }
   }

--- a/src/common/github/GitHubClient.ts
+++ b/src/common/github/GitHubClient.ts
@@ -15,7 +15,7 @@ import IGitHubClient, {
   PullRequestFile
 } from "./IGitHubClient"
 
-const GITHUB_API_VERSION = { "X-GitHub-Api-Version": "2022-11-28" } as const
+const GITHUB_API_VERSION = { "X-GitHub-Api-Version": "2026-03-10" } as const
 
 interface IGitHubOAuthTokenDataSource {
   getOAuthToken(): Promise<{ accessToken: string }>

--- a/src/common/github/GitHubClient.ts
+++ b/src/common/github/GitHubClient.ts
@@ -46,15 +46,19 @@ export default class GitHubClient implements IGitHubClient {
     }
   }
   
+  private makeOctokit(auth: string): Octokit {
+    return new Octokit({ auth, headers: { "X-GitHub-Api-Version": "2022-11-28" } })
+  }
+
   async graphql(request: GraphQLQueryRequest): Promise<GraphQlQueryResponse> {
     const oauthToken = await this.oauthTokenDataSource.getOAuthToken()
-    const octokit = new Octokit({ auth: oauthToken.accessToken })
+    const octokit = this.makeOctokit(oauthToken.accessToken)
     return await octokit.graphql(request.query, request.variables)
   }
-  
+
   async getRepositoryContent(request: GetRepositoryContentRequest): Promise<RepositoryContent> {
     const oauthToken = await this.oauthTokenDataSource.getOAuthToken()
-    const octokit = new Octokit({ auth: oauthToken.accessToken })
+    const octokit = this.makeOctokit(oauthToken.accessToken)
     const response = await octokit.rest.repos.getContent({
       owner: request.repositoryOwner,
       repo: request.repositoryName,
@@ -64,10 +68,10 @@ export default class GitHubClient implements IGitHubClient {
     const item = response.data as GitHubContentItem
     return { downloadURL: item.download_url }
   }
-  
+
   async getPullRequestFiles(request: GetPullRequestFilesRequest): Promise<PullRequestFile[]> {
     const auth = await this.installationAuthenticator(request.appInstallationId)
-    const octokit = new Octokit({ auth: auth.token })
+    const octokit = this.makeOctokit(auth.token)
     const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
       owner: request.repositoryOwner,
       repo: request.repositoryName,
@@ -77,10 +81,10 @@ export default class GitHubClient implements IGitHubClient {
       return { filename: file.filename, status: file.status }
     })
   }
-  
+
   async getPullRequestComments(request: GetPullRequestCommentsRequest): Promise<PullRequestComment[]> {
     const auth = await this.installationAuthenticator(request.appInstallationId)
-    const octokit = new Octokit({ auth: auth.token })
+    const octokit = this.makeOctokit(auth.token)
     const comments = await octokit.paginate(octokit.rest.issues.listComments, {
       owner: request.repositoryOwner,
       repo: request.repositoryName,
@@ -99,10 +103,10 @@ export default class GitHubClient implements IGitHubClient {
     }
     return result
   }
-  
+
   async addCommentToPullRequest(request: AddCommentToPullRequestRequest): Promise<void> {
     const auth = await this.installationAuthenticator(request.appInstallationId)
-    const octokit = new Octokit({ auth: auth.token })
+    const octokit = this.makeOctokit(auth.token)
     await octokit.rest.issues.createComment({
       owner: request.repositoryOwner,
       repo: request.repositoryName,
@@ -110,10 +114,10 @@ export default class GitHubClient implements IGitHubClient {
       body: request.body
     })
   }
-  
+
   async updatePullRequestComment(request: UpdatePullRequestCommentRequest): Promise<void> {
     const auth = await this.installationAuthenticator(request.appInstallationId)
-    const octokit = new Octokit({ auth: auth.token })
+    const octokit = this.makeOctokit(auth.token)
     await octokit.rest.issues.updateComment({
       comment_id: request.commentId,
       owner: request.repositoryOwner,
@@ -124,7 +128,7 @@ export default class GitHubClient implements IGitHubClient {
 
   async compareCommitsWithBasehead(request: CompareCommitsRequest): Promise<CompareCommitsResponse> {
     const oauthToken = await this.oauthTokenDataSource.getOAuthToken()
-    const octokit = new Octokit({ auth: oauthToken.accessToken })
+    const octokit = this.makeOctokit(oauthToken.accessToken)
     const response = await octokit.rest.repos.compareCommitsWithBasehead({
       owner: request.repositoryOwner,
       repo: request.repositoryName,


### PR DESCRIPTION
## Summary

Fixes the following deprecation warning from `@octokit/request`:

> "GET https://api.github.com/repos/shapehq/framna-docs/contents/{path}?ref={ref}" is deprecated. It is scheduled to be removed on Fri, 10 Mar 2028 00:00:00 GMT. See https://docs.github.com/en/rest/about-the-rest-api/api-versions

Passes `X-GitHub-Api-Version: 2026-03-10` on each REST call via a shared `GITHUB_API_VERSION` constant. Constructor-level headers are not propagated by Octokit 5.0.5, so the header must be set per request.